### PR TITLE
Updated the client to use buzz Browser instead of FileGetContents

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -36,8 +36,7 @@ class Client implements HttpClient
      */
     public function __construct(Browser $client = null, MessageFactory $messageFactory = null)
     {
-        if( ! $client)
-        {
+        if( ! $client) {
             $client = new Browser();
             $client->getClient()->setMaxRedirects(0);
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,7 +36,7 @@ class Client implements HttpClient
      */
     public function __construct(Browser $client = null, MessageFactory $messageFactory = null)
     {
-        if(!$client) {
+        if (!$client) {
             $client = new Browser();
             $client->getClient()->setMaxRedirects(0);
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,17 +2,16 @@
 
 namespace Http\Adapter\Buzz;
 
-use Buzz\Client\ClientInterface;
-use Buzz\Client\FileGetContents;
+use Buzz\Browser;
 use Buzz\Exception as BuzzException;
 use Buzz\Message\Request as BuzzRequest;
 use Buzz\Message\Response as BuzzResponse;
+use Http\Client\Exception as HttplugException;
 use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\MessageFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Exception as HttplugException;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -20,7 +19,7 @@ use Http\Client\Exception as HttplugException;
 class Client implements HttpClient
 {
     /**
-     * @var ClientInterface
+     * @var Browser
      */
     private $client;
 
@@ -30,14 +29,13 @@ class Client implements HttpClient
     private $messageFactory;
 
     /**
-     * @param FileGetContents|null $client
-     * @param MessageFactory|null  $messageFactory
+     * Client constructor.
+     * @param Browser|null $client
+     * @param MessageFactory|null $messageFactory
      */
-    public function __construct(FileGetContents $client = null, MessageFactory $messageFactory = null)
+    public function __construct(Browser $client = null, MessageFactory $messageFactory = null)
     {
-        $this->client = $client ?: new FileGetContents();
-        $this->client->setMaxRedirects(0);
-
+        $this->client = $client ?: new Browser();
         $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
     }
 
@@ -117,9 +115,7 @@ class Client implements HttpClient
     /**
      * Get headers from a Buzz response.
      *
-     * @param RequestInterface $request
-     * @param BuzzRequest      $buzzRequest
-     *
+     * @param BuzzResponse $response
      * @return array
      */
     private function getBuzzHeaders(BuzzResponse $response)

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,7 +30,8 @@ class Client implements HttpClient
 
     /**
      * Client constructor.
-     * @param Browser|null $client
+     *
+     * @param Browser|null        $client
      * @param MessageFactory|null $messageFactory
      */
     public function __construct(Browser $client = null, MessageFactory $messageFactory = null)
@@ -116,6 +117,7 @@ class Client implements HttpClient
      * Get headers from a Buzz response.
      *
      * @param BuzzResponse $response
+     *
      * @return array
      */
     private function getBuzzHeaders(BuzzResponse $response)

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,7 +36,7 @@ class Client implements HttpClient
      */
     public function __construct(Browser $client = null, MessageFactory $messageFactory = null)
     {
-        if( ! $client) {
+        if(!$client) {
             $client = new Browser();
             $client->getClient()->setMaxRedirects(0);
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,7 +36,13 @@ class Client implements HttpClient
      */
     public function __construct(Browser $client = null, MessageFactory $messageFactory = null)
     {
-        $this->client = $client ?: new Browser();
+        if( ! $client)
+        {
+            $client = new Browser();
+            $client->getClient()->setMaxRedirects(0);
+        }
+
+        $this->client = $client;
         $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
     }
 

--- a/tests/FileGetContentsHttpAdapterTest.php
+++ b/tests/FileGetContentsHttpAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Http\Adapter\Buzz\Tests;
 
+use Buzz\Browser;
 use Buzz\Client\FileGetContents;
 
 /**
@@ -14,6 +15,6 @@ class FileGetContentsHttpAdapterTest extends HttpAdapterTest
      */
     protected function createBuzzClient()
     {
-        return new FileGetContents();
+        return new Browser(new FileGetContents());
     }
 }

--- a/tests/HttpAdapterTest.php
+++ b/tests/HttpAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Http\Adapter\Buzz\Tests;
 
+use Buzz\Browser;
 use Http\Adapter\Buzz\Client;
 use Http\Client\Tests\HttpClientTest;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
@@ -16,8 +17,11 @@ abstract class HttpAdapterTest extends HttpClientTest
      */
     protected function createHttpAdapter()
     {
+        $buzz = $this->createBuzzClient();
+        $buzz->getClient()->setMaxRedirects(0);
+
         return new Client(
-            $this->createBuzzClient(),
+            $buzz,
             new GuzzleMessageFactory()
         );
     }
@@ -25,7 +29,7 @@ abstract class HttpAdapterTest extends HttpClientTest
     /**
      * Returns a handler for the client.
      *
-     * @return object
+     * @return Browser
      */
     abstract protected function createBuzzClient();
 }


### PR DESCRIPTION
The adapter should use `Browser` object instead of `FileGetContents`. Otherwise the user will not be able to use `Curl` client and pre and post listeners.

Also `setMaxRedirects(0)` is only required for tests, so it should not be in the constructor.

I also tried to add `CurlHttpAdapterTest` but your tests are sending payload with GET request, and Buzz (used with Curl) [choose not to send any payload with the GET/HEAD method.](https://github.com/kriswallsmith/Buzz/blob/master/lib/Buzz/Client/AbstractCurl.php#L87) So I would suggest to change your tests.