### PR TITLE
Add support for using Buzz\Browser instance (fixes #2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php-http/discovery": "^0.9"
     },
     "require-dev": {
+        "ext-curl": "*",
         "php-http/adapter-integration-tests": "^0.3",
         "php-http/client-common": "^1.0",
         "guzzlehttp/psr7": "^1.2",

--- a/tests/BrowserHttpAdapterTest.php
+++ b/tests/BrowserHttpAdapterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Http\Adapter\Buzz\Tests;
+
+use Buzz\Browser;
+use Buzz\Client\FileGetContents;
+
+class BrowserHttpAdapterTest extends HttpAdapterTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createBuzzClient()
+    {
+        $browser = new Browser();
+        $browser->getClient()->setMaxRedirects(0);
+
+        return $browser;
+    }
+}

--- a/tests/CurlHttpAdapterTest.php
+++ b/tests/CurlHttpAdapterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Http\Adapter\Buzz\Tests;
+
+use Buzz\Client\Curl;
+use Http\Adapter\Buzz\Client;
+use Buzz\Message\RequestInterface as BuzzRequestInterface;
+
+class CurlHttpAdapterTest extends HttpAdapterTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createBuzzClient()
+    {
+        $curl = new Curl();
+        $curl->setMaxRedirects(0);
+
+        return $curl;
+    }
+
+    /**
+     * @dataProvider requestProvider
+     * @group        integration
+     */
+    public function testSendRequest($method, $uri, array $headers, $body)
+    {
+        $validMethods = [
+            BuzzRequestInterface::METHOD_POST,
+            BuzzRequestInterface::METHOD_PUT,
+            BuzzRequestInterface::METHOD_DELETE,
+            BuzzRequestInterface::METHOD_PATCH,
+            BuzzRequestInterface::METHOD_OPTIONS,
+        ];
+
+        if (!in_array($method, $validMethods, true) && $body) {
+            $this->setExpectedException(
+                \InvalidArgumentException::class,
+                sprintf('Buzz\Client\Curl does not support %s requests with a body', $method)
+            );
+        }
+
+        parent::testSendRequest($method, $uri, $headers, $body);
+    }
+
+    /**
+     * @dataProvider requestWithOutcomeProvider
+     * @group        integration
+     */
+    public function testSendRequestWithOutcome($uriAndOutcome, $protocolVersion, array $headers, $body)
+    {
+        if ($body && $protocolVersion === '1.1') {
+            $this->setExpectedException(
+                \InvalidArgumentException::class,
+                'Buzz\Client\Curl does not support GET requests with a body'
+            );
+        }
+
+        parent::testSendRequestWithOutcome($uriAndOutcome, $protocolVersion, $headers, $body);
+    }
+}

--- a/tests/DefaultHttpAdapterTest.php
+++ b/tests/DefaultHttpAdapterTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Http\Adapter\Buzz\Tests;
+
+class DefaultHttpAdapterTest extends HttpAdapterTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createBuzzClient()
+    {
+        // returning null here should cause the adapter to create a default client for us
+        return null;
+    }
+}

--- a/tests/FileGetContentsHttpAdapterTest.php
+++ b/tests/FileGetContentsHttpAdapterTest.php
@@ -14,6 +14,9 @@ class FileGetContentsHttpAdapterTest extends HttpAdapterTest
      */
     protected function createBuzzClient()
     {
-        return new FileGetContents();
+        $fileGetContents = new FileGetContents();
+        $fileGetContents->setMaxRedirects(0);
+
+        return $fileGetContents;
     }
 }

--- a/tests/InvalidHttpAdapterTest.php
+++ b/tests/InvalidHttpAdapterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Http\Adapter\Buzz\Tests;
+
+use Http\Adapter\Buzz\Client;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
+
+class InvalidHttpAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The client passed to the Buzz adapter must either implement Buzz\Client\ClientInterface
+     * or be an instance of Buzz\Browser. You passed stdClass.
+     */
+    public function testConstructorThrowsExceptionWhenInvalidClientInstanceIsUsed()
+    {
+        return new Client(
+            new \stdClass(),
+            new GuzzleMessageFactory()
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The client passed to the Buzz adapter must either implement Buzz\Client\ClientInterface
+     * or be an instance of Buzz\Browser. You passed string.
+     */
+    public function testConstructorThrowsExceptionWhenNonObjectClientIsUsed()
+    {
+        return new Client(
+            'This should be an object!',
+            new GuzzleMessageFactory()
+        );
+    }
+}


### PR DESCRIPTION
This change allows instances of Buzz\Browser to be used in the adapater, which is what people generally use with Buzz. Also allow any instance implementing Buzz's ClientInterface to be used, such as the curl implementation.

Note that MultiCurl does not work at this time as it needs to be flushed to send requests.