### PR TITLE
Prepare for stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change Log
 
-## UNRELEASED
+## 1.0.0
 
 ### Changed
 
 - We throw a `RequestException` instead of a `\InvalidExcpetion` when using Buzz' curl client and trying to send GET request with body.
-- We throw a `NetworkException` on network timeout.  
+- We throw a `NetworkException` on network timeout.
+- We require version 0.15.1 of `kriswallsmith/buzz`.  
 
 ## 0.3.0 - 2016-07-18
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
-        "kriswallsmith/buzz": "^0.15",
+        "kriswallsmith/buzz": "^0.15.1",
         "php-http/discovery": "^1.0"
     },
     "require-dev": {
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4-dev"
+            "dev-master": "1.0-dev"
         }
     }
 }


### PR DESCRIPTION
This PR is blocked by release of 0.15.1 of `kriswallsmith/buzz`. 

That version includes a bugfix that ensures exceptions are thrown when using the MultiCurl adapter. 