### PR TITLE
Allow buzz-adapter to be installed for buzz client ^0.17.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
-        "kriswallsmith/buzz": "^0.15.1",
+        "kriswallsmith/buzz": "^0.15.1 || ^0.17.2",
         "php-http/discovery": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | none

| License         | MIT


#### What's in this PR?

This PR enables buzz-adapter to be installed for Buzz client `^0.17.2`.


#### Why?

Some of us are still stuck with Buzz `0.17.2` and we are not able to upgrade to `~1.0`. Due to semantic versioning buzz-adapter version constraint `^0.15.2` won't allow Buzz `0.17`.



